### PR TITLE
Generalise filepaths in notebooks

### DIFF
--- a/extract-dublin-slr-stations.md
+++ b/extract-dublin-slr-stations.md
@@ -25,7 +25,7 @@ import numpy as np
 
 ```python
 dublin_station_names = (
-    pd.read_csv("~/Data/dublin-substation-names.csv")
+    pd.read_excel("data/external/dublin-substation-names.xlsx", engine="openpyxl")
     .assign(slr_station=lambda df: df.slr_station.fillna(df.station)) # replace finglas/mcdermott etc with mesh: orange etc
     .slr_station
     .rename("station")
@@ -36,8 +36,12 @@ dublin_station_names = (
 # Get Ireland Station Special Load Readings (SLR)
 
 ```python
+!wget -O data/external/slr-2019-20.xlsx https://zenodo.org/record/4446588/files/slr-2019-20.xlsx
+```
+
+```python
 ireland_slr = (
-    pd.read_csv("~/Data/slr-2019-20.csv")
+    pd.read_excel("data/external/slr-2019-20.xlsx", engine="openpyxl")
     .assign(total=lambda df: df.station.notnull())
     .assign(station=lambda df: df.station.str.lower().ffill())
 )
@@ -46,7 +50,7 @@ ireland_slr = (
 # Get Dublin station locations
 
 ```python
-dublin_station_locations = gpd.read_file("/home/wsl-rowanm/Data/dublin-stations-google.geojson", driver="GeoJSON")
+dublin_station_locations = gpd.read_file("data/outputs/dublin-stations-google.geojson", driver="GeoJSON")
 ```
 
 # Extract SLR Dublin stations
@@ -100,9 +104,9 @@ dublin_slr_totals_geolocated = dublin_station_locations.merge(dublin_slr_totals)
 # Save
 
 ```python
-dublin_slr_totals_geolocated.to_file("/home/wsl-rowanm/Data/dublin-stations-slr-totals.geojson", driver="GeoJSON")
+dublin_slr_totals_geolocated.to_file("data/outputs/dublin-stations-slr-totals.geojson", driver="GeoJSON")
 ```
 
 ```python
-dublin_slr_totals_geolocated.to_csv("/home/wsl-rowanm/Data/dublin-stations-slr-totals.csv")
+dublin_slr_totals_geolocated.to_csv("data/outputs/dublin-stations-slr-totals.csv")
 ```

--- a/geocode-stations.md
+++ b/geocode-stations.md
@@ -27,7 +27,7 @@ def get_percentage(left, right):
 # Get Dublin stations
 
 ```python
-!wget -q -O data/external/dublin-substation-names.xlsx https://zenodo.org/record/4446622/files/dublin-substation-names.xlsx
+!wget -O data/external/dublin-substation-names.xlsx https://zenodo.org/record/4446622/files/dublin-substation-names.xlsx
 ```
 
 ```python
@@ -46,7 +46,7 @@ dublin_station_addresses = dublin_station_names["town"] + ", Dublin, Ireland"
 ... so can filter out failed non-Dublin results
 
 ```python
-!wget -q -O data/external/dublin_boundary.geojson https://zenodo.org/record/4432494/files/dublin_boundary.geojson 
+!wget -O data/external/dublin_boundary.geojson https://zenodo.org/record/4432494/files/dublin_boundary.geojson 
 ```
 
 ```python

--- a/link-slr-station-to-nearest-network-station.md
+++ b/link-slr-station-to-nearest-network-station.md
@@ -25,13 +25,30 @@ from sklearn.neighbors import BallTree
 # Get LA boundaries
 
 ```python
+!wget -O data/external/dublin_admin_county_boundaries.zip https://zenodo.org/record/4446778/files/dublin_admin_county_boundaries.zip
+```
+
+```python
+!unzip -d data/external data/external/dublin_admin_county_boundaries.zip 
+```
+
+```python
 dublin_admin_county_boundaries = (
-    gpd.read_file("/home/wsl-rowanm/Data/dublin_admin_county_boundaries")
+    gpd.read_file("data/external/dublin_admin_county_boundaries")
     .to_crs(epsg=2157) # read & convert to ITM or epsg=2157
 )
 ```
 
-# Get MV Network
+# Get Network data
+
+
+Must be downloaded from the Codema Google Shared Drive or <span style="color:red">**requested from the ESB**</span>
+
+```python
+network_data = "/home/wsl-rowanm/Data/dublin-electricity-network/"
+```
+
+## Get MV Network
 
 
 - 10
@@ -59,9 +76,7 @@ dublin_admin_county_boundaries = (
 ... from ESB Networks Data Style Mappings v1.1
 
 ```python
-lvmv_network = gpd.read_parquet(
-    "/home/wsl-rowanm/Data/dublin-electricity-network/dublin_lvmv_network.parquet",
-)
+lvmv_network = gpd.read_parquet(f"{network_data}/dublin_lvmv_network.parquet")
 ```
 
 ```python
@@ -81,15 +96,13 @@ base = dublin_admin_county_boundaries.boundary.plot(edgecolor='red', figsize=(25
 mv_network_lines.plot(ax=base, markersize=0.1)
 ```
 
-# Get 38kV, 110kV & 220kV  stations
+## Get 38kV, 110kV & 220kV  stations
 
 ... there is no 400kV station in Dublin
 
 ```python
 hv_network = (
-    gpd.read_parquet(
-        "/home/wsl-rowanm/Data/dublin-electricity-network/dublin_hv_network.parquet",
-    )
+    gpd.read_parquet(f"{network_data}/dublin_hv_network.parquet")
     .to_crs(epsg=2157)
 )
 ```
@@ -109,7 +122,7 @@ hv_stations = (
 ```python
 slr_stations = (
     gpd.read_file(
-        "/home/wsl-rowanm/Data/dublin-stations-slr-totals.geojson",
+        "data/outputs/dublin-stations-slr-totals.geojson",
         driver="GeoJSON",
     )
     .to_crs(epsg=2157)

--- a/link-small-areas-to-nearest-stations.md
+++ b/link-small-areas-to-nearest-stations.md
@@ -25,17 +25,9 @@ from sklearn.neighbors import BallTree
 
 ```python
 station_totals = (
-    gpd.read_file("data/outputs/dublin-station-slr-totals.geojson", driver="GeoJSON")
+    gpd.read_file("data/outputs/dublin-stations-slr-totals.geojson", driver="GeoJSON")
     .to_crs(epsg=2157) # convert to ITM
 )
-```
-
-```python
-station_totals
-```
-
-```python
-station_totals.plot()
 ```
 
 # Get Dublin Small Area Boundaries
@@ -45,7 +37,7 @@ station_totals.plot()
 ```
 
 ```python
-!echo "y" unzip data/external/Small_Areas_Ungeneralised_-_OSi_National_Statistical_Boundaries_-_2015-shp.zip -d data/external/Small_Areas_Ungeneralised_-_OSi_National_Statistical_Boundaries_-_2015-shp
+!unzip data/external/Small_Areas_Ungeneralised_-_OSi_National_Statistical_Boundaries_-_2015-shp.zip -d data/external/Small_Areas_Ungeneralised_-_OSi_National_Statistical_Boundaries_-_2015-shp
 ```
 
 ```python
@@ -55,27 +47,6 @@ small_areas = (
     .loc[:, ["SMALL_AREA", "COUNTYNAME", "geometry"]]
     .to_crs(epsg=2157) # convert to ITM
 )
-```
-
-```python
-small_areas
-```
-
-# Get Small Area demands
-
-... <span style="color:red">**Not yet publicly released**</span>.
-
-```python
-small_area_demand = (
-    gpd.read_file("data/external/small_area_residential_demand.geojson", driver="GeoJSON")
-    .to_crs(epsg=2157) # convert to ITM
-    .loc[:, ["GEOGID", "sa_demand"]]
-    .rename(columns={"GEOGID": "SMALL_AREA"})
-)
-```
-
-```python
-small_area_demand
 ```
 
 # Link Small Areas to nearest station 
@@ -90,14 +61,9 @@ Also see:
 ```python
 station_totals["x"] = station_totals.geometry.x
 station_totals["y"] = station_totals.geometry.y
-```
-
-```python
 small_areas["x"] = small_areas.geometry.centroid.x
 small_areas["y"] = small_areas.geometry.centroid.y
-```
 
-```python
 tree = BallTree(station_totals[['x', 'y']].values, leaf_size=2)
 
 small_areas['distance_nearest'], small_areas['id_nearest'] = tree.query(
@@ -120,6 +86,10 @@ small_areas_with_stations = small_areas.merge(small_area_stations).loc[:, ["SMAL
 ```
 
 ```python
+small_areas_with_stations
+```
+
+```python
 base = small_areas_with_stations.plot(
     column="station", 
     legend=True,
@@ -131,31 +101,4 @@ station_totals.plot(
     ax=base,
     color='k',
 )
-```
-
-# Link small area demands to stations
-
-```python
-small_area_demands_with_stations = small_areas_with_stations.merge(small_area_demand)
-```
-
-```python
-demand_at_stations = small_area_demands_with_stations.groupby("station").sum() / 10**6
-```
-
-```python
-demand_at_stations
-```
-
-```python
-stations_with_demands = pd.merge(
-    demand_at_stations,
-    station_totals,
-    left_index=True,
-    right_on="station"
-)
-```
-
-```python
-stations_with_demands.to_csv("data/outputs/station_demands.csv", index=False)
 ```


### PR DESCRIPTION
So filepaths all use the data folder structure
within this repository ... other than for the
closed-source network data which must be manually
downloaded