### PR TITLE
Save data in a single data dir

### DIFF
--- a/notebooks/link_cad_stations_to_map_stations.ipynb
+++ b/notebooks/link_cad_stations_to_map_stations.ipynb
@@ -22,7 +22,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Get LA boundaries"
+    "# Get Dublin LA boundaries"
    ]
   },
   {
@@ -35,11 +35,11 @@
    "source": [
     "download.download(\n",
     "    url=\"https://zenodo.org/record/4446778/files/dublin_admin_county_boundaries.zip\",\n",
-    "    to_filepath=f\"{data_dir}/external/dublin_admin_county_boundaries.zip\"\n",
+    "    to_filepath=f\"{data_dir}/dublin_admin_county_boundaries.zip\"\n",
     ")\n",
-    "unpack_archive(\n",
-    "    filename=f\"{data_dir}/external/dublin_admin_county_boundaries.zip\",\n",
-    "    extract_dir=f\"{data_dir}/external/dublin_admin_county_boundaries\",\n",
+    "unzip.unzip(\n",
+    "    filename=f\"{data_dir}/dublin_admin_county_boundaries.zip\",\n",
+    "    extract_dir=f\"{data_dir}/dublin_admin_county_boundaries\",\n",
     ")"
    ]
   },
@@ -50,7 +50,7 @@
    "outputs": [],
    "source": [
     "dublin_admin_county_boundaries = io.read_dublin_admin_county_boundaries(\n",
-    "    f\"{data_dir}/external/dublin_admin_county_boundaries\"\n",
+    "    f\"{data_dir}/dublin_admin_county_boundaries\"\n",
     ")"
    ]
   },
@@ -102,13 +102,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "heatmap_stations_ireland = io.read_heatmap(f\"{data_dir}/external/heatmap-download-version-nov-2020.xlsx\")\n",
-    "heatmap_stations_dublin =  gpd.sjoin(\n",
-    "    heatmap_stations_ireland,\n",
-    "    dublin_admin_county_boundaries,\n",
-    "    op=\"within\",\n",
-    ").drop(columns=\"index_right\")\n",
-    "heatmap_stations_dublin_hv = heatmap_stations_dublin.query(\"station_name != 'mv/lv'\")"
+    "download.download(\n",
+    "    url=\"https://esbnetworks.ie/docs/default-source/document-download/heatmap-download-version-nov-2020.xlsx\",\n",
+    "    to_filepath=f\"{data_dir}/heatmap-download-version-nov-2020.xlsx\"\n",
+    ")"
    ]
   },
   {
@@ -117,13 +114,13 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "capacitymap_stations_ireland = io.read_capacitymap(f\"{data_dir}/external/MapDetailsDemand.xlsx\")\n",
-    "capacitymap_stations_dublin = gpd.sjoin(\n",
-    "    capacitymap_stations_ireland,\n",
+    "heatmap_stations_ireland = io.read_heatmap(f\"{data_dir}/heatmap-download-version-nov-2020.xlsx\")\n",
+    "heatmap_stations_dublin =  gpd.sjoin(\n",
+    "    heatmap_stations_ireland,\n",
     "    dublin_admin_county_boundaries,\n",
     "    op=\"within\",\n",
     ").drop(columns=\"index_right\")\n",
-    "capacitymap_stations_dublin_hv = capacitymap_stations_dublin.query(\"station_name != 'mv/lv'\")"
+    "heatmap_stations_dublin_hv = heatmap_stations_dublin.query(\"station_name != 'mv/lv'\")"
    ]
   },
   {
@@ -140,15 +137,6 @@
    "outputs": [],
    "source": [
     "cad_stations_linked_to_heatmap = join.join_nearest_points(cad_stations_dublin, heatmap_stations_dublin_hv)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "cad_stations_linked_to_capacitymap = join.join_nearest_points(cad_stations_dublin, capacitymap_stations_dublin_hv)"
    ]
   },
   {
@@ -197,18 +185,6 @@
     "    axis=1,\n",
     ");\n",
     "\n",
-    "capacitymap_stations_dublin_hv.plot(ax=ax,color=\"red\")\n",
-    "capacitymap_stations_dublin_hv.apply(\n",
-    "    lambda x: ax.annotate(\n",
-    "        text=x[\"station_name\"],\n",
-    "        xy=x.geometry.centroid.coords[0],\n",
-    "        ha='center',\n",
-    "        color=\"white\",\n",
-    "        path_effects=[pe.withStroke(linewidth=2, foreground=\"red\")],\n",
-    "    ),\n",
-    "    axis=1,\n",
-    ");\n",
-    "\n",
     "plt.legend([\"CAD\", \"Heat Map\", \"Capacity Map\"], prop={'size': 50});"
    ]
   },
@@ -225,7 +201,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "f.savefig(f\"{data_dir}/outputs/cad-stations-linked-to-nearest-heatmap-station.png\")"
+    "f.savefig(f\"{data_dir}/cad-stations-linked-to-nearest-heatmap-station.png\")"
    ]
   },
   {
@@ -235,7 +211,7 @@
    "outputs": [],
    "source": [
     "cad_stations_linked_to_heatmap.to_file(\n",
-    "    f\"{data_dir}/outputs/cad-stations-linked-to-nearest-heatmap-station.geojson\",\n",
+    "    f\"{data_dir}/cad-stations-linked-to-nearest-heatmap-station.geojson\",\n",
     "    driver=\"GeoJSON\",\n",
     ")"
    ]

--- a/notebooks/link_small_areas_to_cad_stations_via_network.ipynb
+++ b/notebooks/link_small_areas_to_cad_stations_via_network.ipynb
@@ -57,11 +57,11 @@
    "source": [
     "download.download(\n",
     "    url=\"https://opendata.arcgis.com/datasets/c85e610da1464178a2cd84a88020c8e2_3.zip\",\n",
-    "    to_filepath=f\"{data_dir}/external/Small_Areas_Ungeneralised_-_OSi_National_Statistical_Boundaries_-_2015-shp.zip\",\n",
+    "    to_filepath=f\"{data_dir}/Small_Areas_Ungeneralised_-_OSi_National_Statistical_Boundaries_-_2015-shp.zip\",\n",
     ")\n",
     "unzip.unzip(\n",
-    "    filename=f\"{data_dir}/external/Small_Areas_Ungeneralised_-_OSi_National_Statistical_Boundaries_-_2015-shp.zip\",\n",
-    "    extract_dir=f\"{data_dir}/external/Small_Areas_Ungeneralised_-_OSi_National_Statistical_Boundaries_-_2015-shp\",\n",
+    "    filename=f\"{data_dir}/Small_Areas_Ungeneralised_-_OSi_National_Statistical_Boundaries_-_2015-shp.zip\",\n",
+    "    extract_dir=f\"{data_dir}/Small_Areas_Ungeneralised_-_OSi_National_Statistical_Boundaries_-_2015-shp\",\n",
     ")"
    ]
   },
@@ -71,7 +71,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "small_areas = io.read_dublin_small_areas(f\"{data_dir}/external/Small_Areas_Ungeneralised_-_OSi_National_Statistical_Boundaries_-_2015-shp\")"
+    "small_areas = io.read_dublin_small_areas(f\"{data_dir}/Small_Areas_Ungeneralised_-_OSi_National_Statistical_Boundaries_-_2015-shp\")"
    ]
   },
   {
@@ -88,7 +88,7 @@
    "outputs": [],
    "source": [
     "dublin_admin_county_boundaries = io.read_dublin_admin_county_boundaries(\n",
-    "    f\"{data_dir}/external/dublin_admin_county_boundaries\"\n",
+    "    f\"{data_dir}/dublin_admin_county_boundaries\"\n",
     ")"
    ]
   },
@@ -383,18 +383,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "small_areas_linked_to_stations_via_network.plot(\n",
-    "    edgecolor=\"white\",\n",
-    "    facecolor=\"teal\"\n",
-    ")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
     "if show_plots:\n",
     "    \n",
     "    f, ax = plt.subplots(figsize=(120,120))\n",
@@ -466,6 +454,26 @@
     "\n",
     "    # plt.legend([\"Small Area Station IDs\", \"CAD Stations linked to Heat Map\"], prop={'size': 25});\n",
     "    plt.legend(list(range(5)), prop={'size': 25});"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "\n",
+    "# Save"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "small_areas_linked_to_stations.to_file(\n",
+    "    f\"{data_dir}/small-areas-linked-to-map-stations.geojson\",\n",
+    "    driver=\"GeoJSON\",\n",
+    ")"
    ]
   }
  ],

--- a/notebooks/link_small_areas_to_cad_stations_via_network.py
+++ b/notebooks/link_small_areas_to_cad_stations_via_network.py
@@ -45,19 +45,19 @@ show_plots = True
 
 download.download(
     url="https://opendata.arcgis.com/datasets/c85e610da1464178a2cd84a88020c8e2_3.zip",
-    to_filepath=f"{data_dir}/external/Small_Areas_Ungeneralised_-_OSi_National_Statistical_Boundaries_-_2015-shp.zip",
+    to_filepath=f"{data_dir}/Small_Areas_Ungeneralised_-_OSi_National_Statistical_Boundaries_-_2015-shp.zip",
 )
 unzip.unzip(
-    filename=f"{data_dir}/external/Small_Areas_Ungeneralised_-_OSi_National_Statistical_Boundaries_-_2015-shp.zip",
-    extract_dir=f"{data_dir}/external/Small_Areas_Ungeneralised_-_OSi_National_Statistical_Boundaries_-_2015-shp",
+    filename=f"{data_dir}/Small_Areas_Ungeneralised_-_OSi_National_Statistical_Boundaries_-_2015-shp.zip",
+    extract_dir=f"{data_dir}/Small_Areas_Ungeneralised_-_OSi_National_Statistical_Boundaries_-_2015-shp",
 )
 
-small_areas = io.read_dublin_small_areas(f"{data_dir}/external/Small_Areas_Ungeneralised_-_OSi_National_Statistical_Boundaries_-_2015-shp")
+small_areas = io.read_dublin_small_areas(f"{data_dir}/Small_Areas_Ungeneralised_-_OSi_National_Statistical_Boundaries_-_2015-shp")
 
 # # Get Local Authority boundaries
 
 dublin_admin_county_boundaries = io.read_dublin_admin_county_boundaries(
-    f"{data_dir}/external/dublin_admin_county_boundaries"
+    f"{data_dir}/dublin_admin_county_boundaries"
 )
 
 # # Get MV Network and Get 38kV, 110kV & 220kV  stations
@@ -196,11 +196,6 @@ small_areas_linked_to_stations = pd.concat(
     ]
 ).drop_duplicates(subset="SMALL_AREA")
 
-small_areas_linked_to_stations_via_network.plot(
-    edgecolor="white",
-    facecolor="teal"
-)
-
 if show_plots:
     
     f, ax = plt.subplots(figsize=(120,120))
@@ -272,3 +267,11 @@ if show_plots:
 
     # plt.legend(["Small Area Station IDs", "CAD Stations linked to Heat Map"], prop={'size': 25});
     plt.legend(list(range(5)), prop={'size': 25});
+
+#
+# # Save
+
+small_areas_linked_to_stations.to_file(
+    f"{data_dir}/small-areas-linked-to-map-stations.geojson",
+    driver="GeoJSON",
+)


### PR DESCRIPTION
Was using data/external, data/outputs etc
if user decides an alternative save location then the notebooks
will raise errors if save location folder doesn't exist...
Simpler to just have on data dir