### PR TITLE
Re-add ipynb to git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -133,4 +133,3 @@ data/
 api_keys.txt
 cache/
 .vscode
-*.ipynb


### PR DESCRIPTION
So can convert notebooks to py:light via jupytext
using pre-commit hooks