### PR TITLE
Cluster ESB Map stations

### DIFF
--- a/dublin_electricity_network/cluster.py
+++ b/dublin_electricity_network/cluster.py
@@ -1,0 +1,66 @@
+import geopandas as gpd
+import pandas as pd
+import numpy as np
+from sklearn.cluster import DBSCAN
+from sklearn.cluster import KMeans
+from shapely.geometry import MultiPoint
+from scipy.spatial import cKDTree
+
+
+def _join_nearest_points(gdA, gdB):
+    nA = np.array(list(gdA.geometry.apply(lambda x: (x.x, x.y))))
+    nB = np.array(list(gdB.geometry.apply(lambda x: (x.x, x.y))))
+    btree = cKDTree(nB)
+    dist, idx = btree.query(nA, k=1)
+    gdB_nearest = gdB.iloc[idx].reset_index(drop=True)
+    gdf = pd.concat(
+        [
+            gdA.reset_index(drop=True).drop(columns="geometry"),
+            gdB_nearest,
+        ],
+        axis=1,
+    )
+    return gdf
+
+
+def cluster_itm_coords(
+    gdf,
+    coords,
+    keep_columns,
+    how="knearest",
+    n_clusters=8,
+    max_km_distance_between_points=2500,
+):
+    if how == "knearest":
+        model = KMeans(n_clusters)
+    elif how == "dbscan":
+        model = DBSCAN(
+            eps=max_km_distance_between_points,
+            min_samples=1,
+            algorithm="ball_tree",
+        )
+    else:
+        raise NotImplementedError("Only 'knearest' or 'dbscan' implemented...")
+
+    model.fit(coords)
+    cluster_labels = model.labels_
+    num_clusters = len(set(cluster_labels))
+
+    clusters = gpd.GeoDataFrame(
+        geometry=[MultiPoint(coords[cluster_labels == n]) for n in range(num_clusters)]
+    )
+
+    centermost_points = (
+        clusters.assign(geometry=lambda gdf: gdf.geometry.centroid)
+        .reset_index()
+        .rename(columns={"index": "cluster_id"})
+    )
+
+    gdf_linked_to_clusters = _join_nearest_points(
+        gdf,
+        centermost_points,
+    )
+
+    return gdf_linked_to_clusters[keep_columns].dissolve(
+        by="cluster_id", aggfunc="sum", as_index=False
+    )

--- a/notebooks/cluster_esbmap_stations.py
+++ b/notebooks/cluster_esbmap_stations.py
@@ -1,0 +1,98 @@
+# %% [markdown]
+# Adapted from: https://geoffboeing.com/2014/08/clustering-to-reduce-spatial-data-set-size/
+
+# %%
+from pathlib import Path
+
+import geopandas as gpd
+import matplotlib.pyplot as plt
+import seaborn as sns
+
+from dublin_electricity_network.cluster import cluster_itm_coords
+
+sns.set()
+data_dir = Path("../data")
+
+# %% [markdown]
+# # Read Dublin Small Area boundaries
+dublin_boundary = gpd.read_file(
+    data_dir / "dublin_boundary.geojson",
+    driver="GeoJSON",
+).to_crs(epsg=2157)
+
+# %% [markdown]
+# # Read Dublin HV Station locations
+
+# %%
+esbmap_stations_dublin = (
+    gpd.read_file(
+        data_dir / "esbmap_substations_linked_to_osm.geojson",
+        driver="GeoJSON",
+    )
+    .to_crs(epsg=2157)
+    .assign(
+        slr_load_mva=lambda gdf: gdf["SLR Load MVA"].round(),
+        installed_capacity_mva=lambda gdf: gdf["Installed Capacity MVA"].round(),
+        planned_capacity_mva=lambda gdf: gdf["Demand Planning Capacity"].round(),
+        demand_available_mva=lambda gdf: gdf["Demand Available MVA"].round(),
+        gen_available_firm_mva=lambda gdf: gdf["Gen Available Firm"].round(),
+    )
+)
+
+# %%
+esbmap_capacity_columns = [
+    "slr_load_mva",
+    "installed_capacity_mva",
+    "planned_capacity_mva",
+    "demand_available_mva",
+    "gen_available_firm_mva",
+]
+
+# %% [markdown]
+# # Cluster substations into N groups
+# ... so only link loads to nearest large substation!
+
+# %%
+# coords = esbmap_stations_dublin[["Latitude", "Longitude"]].to_numpy()
+coords = (
+    esbmap_stations_dublin.assign(
+        x=lambda gdf: gdf.geometry.x,
+        y=lambda gdf: gdf.geometry.y,
+    )
+    .loc[:, ["x", "y"]]
+    .to_numpy()
+)
+
+# %% [markdown]
+# # Cluster Substations via DBSCAN
+
+# %%
+keep_columns = esbmap_capacity_columns + ["cluster_id", "geometry"]
+
+# %%
+esbmap_stations_clustered = cluster_itm_coords(
+    esbmap_stations_dublin,
+    coords,
+    how="knearest",
+    n_clusters=10,
+    keep_columns=keep_columns,
+)
+
+# %%
+f, ax = plt.subplots(figsize=(20, 20))
+dublin_boundary.plot(ax=ax, alpha=0.5)
+esbmap_stations_clustered.plot(
+    ax=ax, c="#99cc99", edgecolor="None", alpha=0.7, markersize=120
+)
+esbmap_stations_clustered.apply(
+    lambda gdf: ax.annotate(
+        gdf["demand_available_mva"], xy=gdf.geometry.centroid.coords[0]
+    ),
+    axis="columns",
+)
+esbmap_stations_dublin.plot(ax=ax, c="k", alpha=0.9, markersize=3)
+
+# %%
+esbmap_stations_clustered.to_file(
+    data_dir / "esbmap_stations_clustered.geojson", driver="GeoJSON"
+)


### PR DESCRIPTION
Linking Small Area centroids to the nearest station
results in some small stations receiving more load than
in reality.  Clustering stations into groups means that
Small Areas in cluster zones can be more appropriately
linked to station capacity.

TODO: compare n-buildings * typical load to SLR load for
each cluster of Small Areas